### PR TITLE
Add missing imports to fix SHA256 test

### DIFF
--- a/JsnarkCircuitBuilder/src/examples/tests/hash/SHA256_Test.java
+++ b/JsnarkCircuitBuilder/src/examples/tests/hash/SHA256_Test.java
@@ -8,10 +8,12 @@ import junit.framework.TestCase;
 import org.junit.Test;
 
 import util.Util;
+import circuit.config.Config;
 import circuit.eval.CircuitEvaluator;
 import circuit.structure.CircuitGenerator;
 import circuit.structure.Wire;
 import examples.gadgets.hash.SHA256Gadget;
+import java.math.BigInteger;
 
 /**
  * Tests SHA256 standard cases.


### PR DESCRIPTION
Just a small thing: Had to add these imports to make the SHA256 test(s) compile and run